### PR TITLE
INTERLOK-3555 Update the pom url to point to the right doc

### DIFF
--- a/interlok-jmx-activemq/build.gradle
+++ b/interlok-jmx-activemq/build.gradle
@@ -47,12 +47,12 @@ publishing {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "JMX/JMS provide for ActiveMQ")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "http://interlok.adaptris.net/interlok-docs/advanced-jmx-jms.html")
+        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-jmx-jms")
         properties.appendNode("target", "3.10.0+")
         properties.appendNode("tags", "jmx,jms")
         properties.appendNode("license", "false")
         properties.appendNode("readme", "https://github.com/adaptris/interlok-jmx-jms/raw/develop/README.md")
-
+        properties.appendNode("repository", "https://github.com/adaptris/interlok-jmx-jms")
       }
     }
   }

--- a/interlok-jmx-activemq/build.gradle
+++ b/interlok-jmx-activemq/build.gradle
@@ -46,8 +46,8 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "JMX/JMS provide for ActiveMQ")
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-jmx-jms")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-jmx-jms")
         properties.appendNode("target", "3.10.0+")
         properties.appendNode("tags", "jmx,jms")
         properties.appendNode("license", "false")

--- a/interlok-jmx-amqp/build.gradle
+++ b/interlok-jmx-amqp/build.gradle
@@ -65,8 +65,8 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "JMX/JMS AMQP Provider via Apache QPID")
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-jmx-jms")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-jmx-jms")
         properties.appendNode("target", "3.10.0+")
         properties.appendNode("tags", "jmx,jms")
         properties.appendNode("license", "false")

--- a/interlok-jmx-amqp/build.gradle
+++ b/interlok-jmx-amqp/build.gradle
@@ -66,11 +66,12 @@ publishing {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "JMX/JMS AMQP Provider via Apache QPID")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "http://interlok.adaptris.net/interlok-docs/advanced-jmx-jms.html")
+        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-jmx-jms")
         properties.appendNode("target", "3.10.0+")
         properties.appendNode("tags", "jmx,jms")
         properties.appendNode("license", "false")
         properties.appendNode("readme", "https://github.com/adaptris/interlok-jmx-jms/raw/develop/README.md")
+        properties.appendNode("repository", "https://github.com/adaptris/interlok-jmx-jms")
       }
     }
   }

--- a/interlok-jmx-jms-common/build.gradle
+++ b/interlok-jmx-jms-common/build.gradle
@@ -42,11 +42,12 @@ publishing {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "JMX/JMS code shared across providers")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "http://interlok.adaptris.net/interlok-docs/advanced-jmx-jms.html")
+        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-jmx-jms")
         properties.appendNode("target", "3.10.0+")
         properties.appendNode("tags", "jmx,jms")
         properties.appendNode("license", "false")
         properties.appendNode("readme", "https://github.com/adaptris/interlok-jmx-jms/raw/develop/README.md")
+        properties.appendNode("repository", "https://github.com/adaptris/interlok-jmx-jms")
       }
     }
   }

--- a/interlok-jmx-jms-common/build.gradle
+++ b/interlok-jmx-jms-common/build.gradle
@@ -41,8 +41,8 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "JMX/JMS code shared across providers")
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-jmx-jms")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-jmx-jms")
         properties.appendNode("target", "3.10.0+")
         properties.appendNode("tags", "jmx,jms")
         properties.appendNode("license", "false")

--- a/interlok-jmx-jms-stubs/build.gradle
+++ b/interlok-jmx-jms-stubs/build.gradle
@@ -58,8 +58,8 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "Test scaffolding for JMX/JMS Tests; of no use at Interlok runtime")
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-jmx-jms")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-jmx-jms")
         properties.appendNode("target", "3.10.0+")
         properties.appendNode("tags", "jmx,jms")
         properties.appendNode("license", "false")

--- a/interlok-jmx-jms-stubs/build.gradle
+++ b/interlok-jmx-jms-stubs/build.gradle
@@ -59,11 +59,12 @@ publishing {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "Test scaffolding for JMX/JMS Tests; of no use at Interlok runtime")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "http://interlok.adaptris.net/interlok-docs/advanced-jmx-jms.html")
+        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-jmx-jms")
         properties.appendNode("target", "3.10.0+")
         properties.appendNode("tags", "jmx,jms")
         properties.appendNode("license", "false")
         properties.appendNode("developerOnly", "true")
+        properties.appendNode("repository", "https://github.com/adaptris/interlok-jmx-jms")
       }
     }
   }

--- a/interlok-jmx-rabbitmq/build.gradle
+++ b/interlok-jmx-rabbitmq/build.gradle
@@ -51,11 +51,12 @@ publishing {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "JMX/JMS RabbitMQ Provider")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "http://interlok.adaptris.net/interlok-docs/advanced-jmx-jms.html")
+        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-jmx-jms")          
         properties.appendNode("target", "3.10.0+")
         properties.appendNode("tags", "jmx,jms")
         properties.appendNode("license", "false")
         properties.appendNode("readme", "https://github.com/adaptris/interlok-jmx-jms/raw/develop/README.md")
+        properties.appendNode("repository", "https://github.com/adaptris/interlok-jmx-jms")
       }
     }
   }

--- a/interlok-jmx-rabbitmq/build.gradle
+++ b/interlok-jmx-rabbitmq/build.gradle
@@ -50,8 +50,8 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "JMX/JMS RabbitMQ Provider")
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-jmx-jms")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-jmx-jms")          
         properties.appendNode("target", "3.10.0+")
         properties.appendNode("tags", "jmx,jms")
         properties.appendNode("license", "false")

--- a/interlok-jmx-solace/build.gradle
+++ b/interlok-jmx-solace/build.gradle
@@ -52,11 +52,12 @@ publishing {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "JMX/JMS Provider for Solace JMS")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "http://interlok.adaptris.net/interlok-docs/advanced-jmx-jms.html")
+        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-jmx-jms")
         properties.appendNode("target", "3.10.0+")
         properties.appendNode("tags", "jmx,jms")
         properties.appendNode("license", "false")
         properties.appendNode("readme", "https://github.com/adaptris/interlok-jmx-jms/raw/develop/README.md")
+        properties.appendNode("repository", "https://github.com/adaptris/interlok-jmx-jms")
       }
     }
   }

--- a/interlok-jmx-solace/build.gradle
+++ b/interlok-jmx-solace/build.gradle
@@ -51,8 +51,8 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "JMX/JMS Provider for Solace JMS")
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-jmx-jms")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-jmx-jms")
         properties.appendNode("target", "3.10.0+")
         properties.appendNode("tags", "jmx,jms")
         properties.appendNode("license", "false")


### PR DESCRIPTION
## Motivation
The documentation was broken since we changed the doc site

## Modification
Fix the doc url
Add a repo url

## Result
The pom has a correct doc url and a new repo url

## Testing
Check that the new url and repo url exists in the POM file after running gradle generatePomFileForMavenJavaPublication.