### PR TITLE
Bump activemqVersion from 5.16.0 to 5.16.1

### DIFF
--- a/interlok-jmx-activemq/build.gradle
+++ b/interlok-jmx-activemq/build.gradle
@@ -1,6 +1,6 @@
 ext {
   componentName='Interlok JMX/JMS ActiveMQ provider'
-  activemqVersion = '5.16.0'
+  activemqVersion = '5.16.1'
 }
 
 dependencies {

--- a/interlok-jmx-jms-stubs/build.gradle
+++ b/interlok-jmx-jms-stubs/build.gradle
@@ -1,7 +1,7 @@
 ext {
   componentName='Interlok JMX/JMS Test Stubs'
   jacksonVersion="2.12.1"
-  activemqVersion = '5.16.0'
+  activemqVersion = '5.16.1'
 }
 
 dependencies {


### PR DESCRIPTION
## Motivation

There is a vulnerability in 5.16.0: CVE-2021-26117.
Changes already applied in develop: https://github.com/adaptris/interlok-jmx-jms/pull/111

## Modification

Updates activemq-jaas from 5.16.0 to 5.16.1

