### PR TITLE
INTERLOK-3727 #comment Bump spring to 5.3.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext {
   repoPassword = project.hasProperty('repoPassword') ? project.getProperty('repoPassword') : 'unknown'
   defaultNexusRepo = project.hasProperty('defaultNexusRepo') ? project.getProperty('defaultNexusRepo') : 'https://repo1.maven.org/maven2/'
   organizationName = "Adaptris Ltd"
-  springVersion = '4.3.30.RELEASE'
+  springVersion = '5.3.4'
   slf4jVersion = '1.7.30'
   mockitoVersion = '3.7.7'
 }


### PR DESCRIPTION
## Motivation

Update to the latest spring version to be inline with the UI and activemq

## Modification

Bump spring to 5.3.4.

## Result

Nothing should change for the user, just using the latest lib version.

## Testing

- The tests should pass `graldew clean check`.
- Running an adapter with jmx-jms should work. Example project attached. [jmx-jms.zip](https://github.com/adaptris/interlok-jmx-jms/files/6040060/jmx-jms.zip)

The interlok config doesn't do anything but is configured to use jmx over activemq.
You can build the adapter with `gradlew clean assemble`
then start the adapter from the `./build/distribution` dir with `java -jar lib/interlok-boot.jar`
