### PR TITLE
INTERLOK-4324 Deprecate JMX over JMS

### DIFF
--- a/interlok-jmx-activemq/build.gradle
+++ b/interlok-jmx-activemq/build.gradle
@@ -53,6 +53,7 @@ publishing {
         properties.appendNode("license", "false")
         properties.appendNode("readme", "https://github.com/adaptris/interlok-jmx-jms/raw/develop/README.md")
         properties.appendNode("repository", "https://github.com/adaptris/interlok-jmx-jms")
+        properties.appendNode("deprecated", "This component has been deprecated with no replacement and will be removed in a future version")
       }
     }
   }

--- a/interlok-jmx-amqp/build.gradle
+++ b/interlok-jmx-amqp/build.gradle
@@ -73,6 +73,7 @@ publishing {
         properties.appendNode("license", "false")
         properties.appendNode("readme", "https://github.com/adaptris/interlok-jmx-jms/raw/develop/README.md")
         properties.appendNode("repository", "https://github.com/adaptris/interlok-jmx-jms")
+        properties.appendNode("deprecated", "This component has been deprecated with no replacement and will be removed in a future version")
       }
     }
   }

--- a/interlok-jmx-jms-common/build.gradle
+++ b/interlok-jmx-jms-common/build.gradle
@@ -50,6 +50,7 @@ publishing {
         properties.appendNode("license", "false")
         properties.appendNode("readme", "https://github.com/adaptris/interlok-jmx-jms/raw/develop/README.md")
         properties.appendNode("repository", "https://github.com/adaptris/interlok-jmx-jms")
+        properties.appendNode("deprecated", "This component has been deprecated with no replacement and will be removed in a future version")
       }
     }
   }

--- a/interlok-jmx-jms-stubs/build.gradle
+++ b/interlok-jmx-jms-stubs/build.gradle
@@ -67,6 +67,7 @@ publishing {
         properties.appendNode("license", "false")
         properties.appendNode("developerOnly", "true")
         properties.appendNode("repository", "https://github.com/adaptris/interlok-jmx-jms")
+        properties.appendNode("deprecated", "This component has been deprecated with no replacement and will be removed in a future version")
       }
     }
   }

--- a/interlok-jmx-rabbitmq/build.gradle
+++ b/interlok-jmx-rabbitmq/build.gradle
@@ -58,6 +58,7 @@ publishing {
         properties.appendNode("license", "false")
         properties.appendNode("readme", "https://github.com/adaptris/interlok-jmx-jms/raw/develop/README.md")
         properties.appendNode("repository", "https://github.com/adaptris/interlok-jmx-jms")
+        properties.appendNode("deprecated", "This component has been deprecated with no replacement and will be removed in a future version")
       }
     }
   }

--- a/interlok-jmx-solace/build.gradle
+++ b/interlok-jmx-solace/build.gradle
@@ -59,6 +59,7 @@ publishing {
         properties.appendNode("license", "false")
         properties.appendNode("readme", "https://github.com/adaptris/interlok-jmx-jms/raw/develop/README.md")
         properties.appendNode("repository", "https://github.com/adaptris/interlok-jmx-jms")
+        properties.appendNode("deprecated", "This component has been deprecated with no replacement and will be removed in a future version")
       }
     }
   }


### PR DESCRIPTION
## Motivation

We won't to deprecated JMX over JMS as the spring lib we are using is deprecated and will be removed in future version.
It is also not really used anymore.

## Modification

Add a deprecated comment in the gradle > pom file which will be shown the optional components search.

## PR Checklist

- [x] been self-reviewed.

## Result

A warning will be displayed in the optional components search.

## Testing

The build should pass and once a snapshot version is released we should see the deprecated message in the pom file.
